### PR TITLE
Use up-to-date column info for creating views

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    tidus (1.0.4.dev)
+    tidus (1.0.5)
       activerecord (>= 3.2)
 
 GEM
@@ -25,7 +25,7 @@ GEM
     diff-lcs (1.2.5)
     i18n (0.7.0)
     json (1.8.2)
-    minitest (5.6.1)
+    minitest (5.5.1)
     rake (10.0.4)
     rspec (2.14.1)
       rspec-core (~> 2.14.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    tidus (1.0.4)
+    tidus (1.0.4.dev)
       activerecord (>= 3.2)
 
 GEM
@@ -25,7 +25,7 @@ GEM
     diff-lcs (1.2.5)
     i18n (0.7.0)
     json (1.8.2)
-    minitest (5.5.1)
+    minitest (5.6.1)
     rake (10.0.4)
     rspec (2.14.1)
       rspec-core (~> 2.14.0)

--- a/lib/tidus/query.rb
+++ b/lib/tidus/query.rb
@@ -9,6 +9,10 @@ module Tidus
     end
 
     def create_view
+      # Make sure we have up-to-date column information in case a column was changed
+      # in a migration directly before.
+      reset_column_information
+
       connection.execute(create_query)
     end
 

--- a/lib/tidus/version.rb
+++ b/lib/tidus/version.rb
@@ -1,3 +1,3 @@
 module Tidus
-  VERSION = "1.0.4.dev"
+  VERSION = "1.0.5"
 end

--- a/lib/tidus/version.rb
+++ b/lib/tidus/version.rb
@@ -1,3 +1,3 @@
 module Tidus
-  VERSION = "1.0.4"
+  VERSION = "1.0.4.dev"
 end


### PR DESCRIPTION
Previously, e.g. when removing a column in a migration, tidus would
try to create a view with the deleted column and fail.