### PR TITLE
Multiple conflicting views for the same table when using Single Table Inheritance

### DIFF
--- a/lib/tasks/views.rake
+++ b/lib/tasks/views.rake
@@ -2,7 +2,7 @@ namespace :db do
   desc "Clears all the views which are currently existing"
   task :clear_views do
     Rails.application.eager_load! if defined?(Rails)
-    ActiveRecord::Base.descendants.each do |c|
+    ActiveRecord::Base.subclasses.each do |c|
       next if c.table_name == "schema_migrations"
       puts "Clearing view '#{c.view_name}' for table '#{c.table_name}'"
 
@@ -13,7 +13,7 @@ namespace :db do
   desc "Generates all the views for the models"
   task :generate_views do
     Rails.application.eager_load! if defined?(Rails)
-    ActiveRecord::Base.descendants.each do |c|
+    ActiveRecord::Base.subclasses.each do |c|
       next if c.table_name == "schema_migrations" || c.skip_anonymization?
 
       if ActiveRecord::Base.connection.table_exists? c.table_name

--- a/spec/lib/tasks/views_rake_spec.rb
+++ b/spec/lib/tasks/views_rake_spec.rb
@@ -23,7 +23,7 @@ describe "database view clearing rake task" do
       another_table.should_receive(:view_name).and_return("another_table_anonymized")
       another_table.should_receive(:clear_view)
 
-      ActiveRecord::Base.should_receive(:descendants).and_return([schema_migrations, another_table])
+      ActiveRecord::Base.should_receive(:subclasses).and_return([schema_migrations, another_table])
       @rake[@rake_task_name].invoke
     end
   end
@@ -52,7 +52,7 @@ describe "database view clearing rake task" do
       another_table.should_receive(:create_view)
       another_table.should_receive(:skip_anonymization?)
 
-      ActiveRecord::Base.should_receive(:descendants)
+      ActiveRecord::Base.should_receive(:subclasses)
                         .and_return([schema_migrations, another_table,
                                      nonexistent, skip_anonymization])
       connection = Object.new


### PR DESCRIPTION
We had some trouble using Tidus in our models that use STI: unless we marked all the deeper descendants to `skip_anonymization`, the gem would try to create multiple views for the same table, resulting in SQL errors.

This patch would make anonymization run only on direct descendants of `ActiveRecord::Base`, thus skipping the "deep" models that share the same table. It's not a silver bullet and it would prevent, for example, to have different anonymization strategies for each of the child models, but that wouldn't have worked anyway with the current implementation.

A more thorough solution would require changes about how the SQL is generated (e.g. multiple views for the same table, discriminating on the `type` column), but this is a quick solution to prevent at least the tasks from failing without manual intervention on all the models.