### PR TITLE
Using descendants instead of subclasses again

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,20 +1,20 @@
 PATH
   remote: .
   specs:
-    tidus (1.0.8)
+    tidus (1.0.9)
       activerecord (>= 3.2)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (4.2.5)
-      activesupport (= 4.2.5)
+    activemodel (4.2.7.1)
+      activesupport (= 4.2.7.1)
       builder (~> 3.1)
-    activerecord (4.2.5)
-      activemodel (= 4.2.5)
-      activesupport (= 4.2.5)
+    activerecord (4.2.7.1)
+      activemodel (= 4.2.7.1)
+      activesupport (= 4.2.7.1)
       arel (~> 6.0)
-    activesupport (4.2.5)
+    activesupport (4.2.7.1)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
@@ -25,7 +25,7 @@ GEM
     diff-lcs (1.2.5)
     i18n (0.7.0)
     json (1.8.3)
-    minitest (5.8.3)
+    minitest (5.9.0)
     rake (10.0.4)
     rspec (2.14.1)
       rspec-core (~> 2.14.0)
@@ -48,3 +48,6 @@ DEPENDENCIES
   rspec (~> 2.14.1)
   sqlite3 (~> 1.3.10)
   tidus!
+
+BUNDLED WITH
+   1.12.5

--- a/lib/tasks/views.rake
+++ b/lib/tasks/views.rake
@@ -2,7 +2,7 @@ namespace :db do
   desc "Clears all the views which are currently existing"
   task :clear_views do
     Rails.application.eager_load! if defined?(Rails)
-    ActiveRecord::Base.subclasses.each do |c|
+    ActiveRecord::Base.descendants.each do |c|
       next if c.table_name == "schema_migrations"
       puts "Clearing view '#{c.view_name}' for table '#{c.table_name}'"
 
@@ -13,7 +13,7 @@ namespace :db do
   desc "Generates all the views for the models"
   task :generate_views do
     Rails.application.eager_load! if defined?(Rails)
-    ActiveRecord::Base.subclasses.each do |c|
+    ActiveRecord::Base.descendants.each do |c|
       next if c.table_name == "schema_migrations" || c.skip_anonymization?
 
       if ActiveRecord::Base.connection.table_exists? c.table_name

--- a/lib/tidus/version.rb
+++ b/lib/tidus/version.rb
@@ -1,3 +1,3 @@
 module Tidus
-  VERSION = "1.0.8"
+  VERSION = "1.0.9"
 end

--- a/spec/lib/tasks/views_rake_spec.rb
+++ b/spec/lib/tasks/views_rake_spec.rb
@@ -23,7 +23,7 @@ describe "database view clearing rake task" do
       another_table.should_receive(:view_name).and_return("another_table_anonymized")
       another_table.should_receive(:clear_view)
 
-      ActiveRecord::Base.should_receive(:subclasses).and_return([schema_migrations, another_table])
+      ActiveRecord::Base.should_receive(:descendants).and_return([schema_migrations, another_table])
       @rake[@rake_task_name].invoke
     end
   end
@@ -52,7 +52,7 @@ describe "database view clearing rake task" do
       another_table.should_receive(:create_view)
       another_table.should_receive(:skip_anonymization?)
 
-      ActiveRecord::Base.should_receive(:subclasses)
+      ActiveRecord::Base.should_receive(:descendants)
                         .and_return([schema_migrations, another_table,
                                      nonexistent, skip_anonymization])
       connection = Object.new


### PR DESCRIPTION
We changed it a while ago due to a pull request and I didn't think all cases through before I merged it. Using descendants is more flexible and skip_anonymization allows ignoring certain tables if necessary.