### PR TITLE
Add EAN anonymizer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,6 @@ rvm:
   - 2.1.0
   - 2.4.0
   - 2.5.0
+before_install: gem install bundler -v '1.17.3'
 script:
   - bundle exec rspec

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 rvm:
   - 2.1.0
-  - 2.4.0
+  - 2.4.1
   - 2.5.0
 before_install: gem install bundler -v '1.17.3'
 script:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,31 +1,31 @@
 PATH
   remote: .
   specs:
-    tidus (1.0.9)
+    tidus (1.1.0)
       activerecord (>= 3.2)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (4.2.7.1)
-      activesupport (= 4.2.7.1)
+    activemodel (4.2.11)
+      activesupport (= 4.2.11)
       builder (~> 3.1)
-    activerecord (4.2.7.1)
-      activemodel (= 4.2.7.1)
-      activesupport (= 4.2.7.1)
+    activerecord (4.2.11)
+      activemodel (= 4.2.11)
+      activesupport (= 4.2.11)
       arel (~> 6.0)
-    activesupport (4.2.7.1)
+    activesupport (4.2.11)
       i18n (~> 0.7)
-      json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
-    arel (6.0.3)
-    builder (3.2.2)
+    arel (6.0.4)
+    builder (3.2.3)
+    concurrent-ruby (1.1.3)
     diff-lcs (1.2.5)
-    i18n (0.7.0)
-    json (1.8.6)
-    minitest (5.9.0)
+    i18n (0.9.5)
+      concurrent-ruby (~> 1.0)
+    minitest (5.11.3)
     rake (10.0.4)
     rspec (2.14.1)
       rspec-core (~> 2.14.0)
@@ -36,8 +36,8 @@ GEM
       diff-lcs (>= 1.1.3, < 2.0)
     rspec-mocks (2.14.6)
     sqlite3 (1.3.10)
-    thread_safe (0.3.5)
-    tzinfo (1.2.2)
+    thread_safe (0.3.6)
+    tzinfo (1.2.5)
       thread_safe (~> 0.1)
 
 PLATFORMS
@@ -48,3 +48,6 @@ DEPENDENCIES
   rspec (~> 2.14.1)
   sqlite3 (~> 1.3.10)
   tidus!
+
+BUNDLED WITH
+   1.17.2

--- a/lib/tidus/strategies/ean_anonymizer.rb
+++ b/lib/tidus/strategies/ean_anonymizer.rb
@@ -1,0 +1,6 @@
+# encoding: utf-8
+
+module Tidus
+  class EanAnonymizer < Tidus::BaseSelector
+  end
+end

--- a/lib/tidus/strategies/postgresql/ean_anonymizer.rb
+++ b/lib/tidus/strategies/postgresql/ean_anonymizer.rb
@@ -1,0 +1,147 @@
+module Tidus
+  module Postgresql
+    class EanAnonymizer
+      BASE_MAPPING          = '0123456789'.freeze
+      DEFAULT_MAPPING_START = 1.freeze
+
+      def self.anonymize(table_name, column_name, options = {})
+        mapping_snippet = build_mapped_digit_snippet(column_name, options)
+
+        query = <<-SQL
+          (
+            SELECT
+              string_agg(new_digits.digit::TEXT, ''::TEXT)
+            FROM (
+              (
+                SELECT
+                  pos,
+                  digit
+                FROM (
+                  #{mapping_snippet}
+                ) AS where_sub
+                ORDER BY pos ASC
+              )
+              UNION ALL
+              (
+                SELECT
+                  LENGTH(#{column_name}::TEXT) AS pos,
+                  (
+                    10
+                    -
+                    (
+                      (
+                        SELECT
+                          SUM(digit)
+                        FROM (
+                          #{mapping_snippet}
+                        ) AS where_sub
+                        WHERE pos % 2 = LENGTH(#{column_name}::TEXT) % 2
+                      )
+                      +
+                      (
+                        SELECT
+                          SUM(digit)
+                        FROM (
+                          #{mapping_snippet}
+                        ) AS where_sub
+                        WHERE pos % 2 = (LENGTH(#{column_name}::TEXT) - 1) % 2
+                      ) * 3
+                    ) % 10
+                  ) % 10 AS digit
+              )
+            ) new_digits
+          )
+          SQL
+
+        return query.gsub!(/\n/, '').gsub!(/\ +/, ' ')
+      end
+
+      # Generates a new mapping if no cache_key is given
+      # Generates a new mapping if the cache_key is unknown
+      # Reuses the found mapping if the cache_key is known
+      def self.retrieve_mapping(cache_key)
+        @cached_mappings ||= {}
+        mapping = @cached_mappings[cache_key]
+
+        if mapping == nil
+          mapping = {
+            base:        BASE_MAPPING,
+            replacement: BASE_MAPPING.split('').shuffle.join('')
+          }
+        end
+
+        if cache_key != nil
+          @cached_mappings[cache_key] = mapping
+        end
+
+        return mapping
+      end
+
+      def self.build_mapped_digit_snippet(column_name, options)
+        substrings = build_digit_mapping(column_name, options)
+
+        return <<-SQL
+          SELECT
+            *
+          FROM (
+            SELECT
+              ROW_NUMBER() over () AS pos,
+              digit::INT
+            FROM (
+              SELECT
+                REGEXP_SPLIT_TO_TABLE(
+                  #{substrings.join(' || ')},
+                  ''
+                ) AS digit
+            ) AS sub
+          ) AS sub
+          WHERE pos < LENGTH(#{column_name}::TEXT)
+        SQL
+      end
+
+      def self.build_digit_mapping(column_name, options)
+        mapping = retrieve_mapping(options[:cache_key])
+
+        options[:start] ||= DEFAULT_MAPPING_START
+
+        # reduce length by 1 to take away the check digit
+        total_length = "LENGTH(#{column_name}::TEXT) - 1"
+        length = options[:length] || total_length
+
+        substrings = []
+
+        if options[:start] != DEFAULT_MAPPING_START
+          substrings << build_substring_snippet(
+                          column_name,
+                          DEFAULT_MAPPING_START,
+                          options[:start] - DEFAULT_MAPPING_START
+                        )
+        end
+
+        translate_part = <<-SNIPPET
+          TRANSLATE(
+            #{build_substring_snippet(column_name, options[:start], length)},
+            '#{mapping[:base]}',
+            '#{mapping[:replacement]}'
+          )
+        SNIPPET
+
+        substrings << translate_part.gsub(/\n/, '').gsub(/\ +/, ' ')
+
+        if options[:length] != nil
+          substrings << build_substring_snippet(
+                          column_name,
+                          "#{options[:start]} + #{options[:length]}",
+                          "#{total_length} - #{options[:start]}"
+                        )
+        end
+
+        return substrings
+      end
+
+      def self.build_substring_snippet(column_name, start, length)
+        return "SUBSTRING(#{column_name}::TEXT, #{start}, #{length})"
+      end
+    end
+  end
+end

--- a/lib/tidus/version.rb
+++ b/lib/tidus/version.rb
@@ -1,3 +1,3 @@
 module Tidus
-  VERSION = "1.0.9"
+  VERSION = "1.1.0"
 end

--- a/readme.md
+++ b/readme.md
@@ -34,9 +34,15 @@ The rules to ensure anonymization can be defined as follows
             -  `:type`  The type to which the column value and the condition value should be cast for comparision. Default is `text`.
             -  `:comparator`  Infix function with which to compare the values. Default is `=`
             -  `:result` Value which should be used as a replacement in case the condition is met.
+- `:ean`
+    - Replaces all or part of an ean code with a mapping of the digits to scramble the real value.
+    - Options:
+        - `:start` Defines the starting point in the value string. Defaults to the beginning if nothing is given.
+        - `:length` Defines the length of the translation. Defaults to the whole remaining length if nothing is given.
+        - `:cache_key` Allows to cache the generated mapping to re-use on another model. Will generate a new mapping if no caching is enabled.
 - `:email`
     -  Replaces the part before the `@` by an MD5 Hash of the value with the given length. A hash function is used to have anonymization while allowing to find out whether two addresses are the same.
-    -  Options:
+    - Options:
         -  `:length`    Specifies the length of the part which should be kept before the `@`. Default is 15. Maximum with MD5 is 32.
 - `:null`
     - Replaces any value with `NULL`
@@ -75,6 +81,7 @@ Note: to provide your own anonymization strategy you can also provide a class na
 |                  | PostgreSQL | SQLite3 | MySQL |
 |------------------|------------|---------|-------|
 | cond             |      √     |    x    |   x   |
+| ean              |      √     |    x    |   x   |
 | email            |      √     |    x    |   x   |
 | null             |      √     |    √    |   x   |
 | overlay          |      √     |    x    |   x   |

--- a/spec/lib/tidus/strategies/ean_anonymizer_spec.rb
+++ b/spec/lib/tidus/strategies/ean_anonymizer_spec.rb
@@ -1,0 +1,9 @@
+# encoding: utf-8
+
+require 'spec_helper'
+
+describe Tidus::EanAnonymizer do
+  it "inherits from BaseSelector" do
+    described_class.ancestors.include?(Tidus::BaseSelector)
+  end
+end

--- a/spec/lib/tidus/strategies/postgresql/ean_anonymizer_spec.rb
+++ b/spec/lib/tidus/strategies/postgresql/ean_anonymizer_spec.rb
@@ -1,0 +1,312 @@
+# encoding: utf-8
+
+require 'spec_helper'
+
+describe Tidus::Postgresql::EanAnonymizer do
+  let(:table_name)  { 'table' }
+  let(:column_name) { 'ean' }
+  let(:start)  { 3 }
+  let(:length) { 7 }
+  let(:cache_key) { 'ean_mapping' }
+
+  let(:options) do
+    {
+      start:     start,
+      length:    length,
+      cache_key: cache_key
+    }
+  end
+
+  describe '.anonymize' do
+    let(:start)  { nil }
+    let(:length) { nil }
+
+    let(:mapping) do
+      {
+        base:        '0123456789',
+        replacement: '5678901234'
+      }
+    end
+
+    before do
+      allow(described_class)
+        .to receive(:retrieve_mapping)
+        .with(cache_key)
+        .and_return(mapping)
+    end
+
+    it 'builds the query snippet' do
+      expectation = <<-SQL
+          (
+            SELECT
+              string_agg(new_digits.digit::TEXT, ''::TEXT)
+            FROM (
+              (
+                SELECT
+                  pos,
+                  digit
+                FROM (
+                  SELECT
+                    *
+                  FROM (
+                    SELECT
+                      ROW_NUMBER() over () AS pos,
+                      digit::INT
+                    FROM (
+                      SELECT
+                        REGEXP_SPLIT_TO_TABLE(
+                          TRANSLATE(
+                            SUBSTRING(ean::TEXT, 1, LENGTH(ean::TEXT) - 1),
+                            '0123456789',
+                            '5678901234'
+                          ),
+                          ''
+                        ) AS digit
+                    ) AS sub
+                  ) AS sub
+                  WHERE pos < LENGTH(ean::TEXT)
+                ) AS where_sub
+                ORDER BY pos ASC
+              )
+              UNION ALL
+              (
+                SELECT
+                  LENGTH(ean::TEXT) AS pos,
+                  (
+                    10
+                    -
+                    (
+                      (
+                        SELECT
+                          SUM(digit)
+                        FROM (
+                          SELECT
+                            *
+                          FROM (
+                            SELECT
+                              ROW_NUMBER() over () AS pos,
+                              digit::INT
+                            FROM (
+                              SELECT
+                                REGEXP_SPLIT_TO_TABLE(
+                                  TRANSLATE(
+                                    SUBSTRING(ean::TEXT, 1, LENGTH(ean::TEXT) - 1),
+                                    '0123456789',
+                                    '5678901234'
+                                  ),
+                                  ''
+                                ) AS digit
+                            ) AS sub
+                          ) AS sub
+                          WHERE pos < LENGTH(ean::TEXT)
+                        ) AS where_sub
+                        WHERE pos % 2 = LENGTH(ean::TEXT) % 2
+                      )
+                      +
+                      (
+                        SELECT
+                          SUM(digit)
+                        FROM (
+                          SELECT
+                            *
+                          FROM (
+                            SELECT
+                              ROW_NUMBER() over () AS pos,
+                              digit::INT
+                            FROM (
+                              SELECT
+                                REGEXP_SPLIT_TO_TABLE(
+                                  TRANSLATE(
+                                    SUBSTRING(ean::TEXT, 1, LENGTH(ean::TEXT) - 1),
+                                    '0123456789',
+                                    '5678901234'
+                                  ),
+                                  ''
+                                ) AS digit
+                            ) AS sub
+                          ) AS sub
+                          WHERE pos < LENGTH(ean::TEXT)
+                        ) AS where_sub
+                        WHERE pos % 2 = (LENGTH(ean::TEXT) - 1) % 2
+                      ) * 3
+                    ) % 10
+                  ) % 10 AS digit
+                )
+              ) new_digits
+            )
+      SQL
+
+      expect(described_class.anonymize(table_name, column_name, options))
+        .to eq(expectation.gsub!(/\n/, '').gsub!(/\ +/, ' '))
+    end
+  end
+
+  describe '.retrieve_mapping' do
+    let(:retrieve_mapping_call) do
+      described_class.retrieve_mapping(cache_key)
+    end
+
+    before do
+      described_class.instance_variable_set("@cached_mapping", nil)
+    end
+
+    context 'when no cache_key is given' do
+      let(:cache_key) { nil }
+
+      it 'builds a new mapping' do
+        mapping = described_class.retrieve_mapping(cache_key)
+
+        expect(mapping[:base]).to eq(described_class::BASE_MAPPING)
+        expect(mapping[:replacement].class).to eq(String)
+
+        mapping2 = described_class.retrieve_mapping(cache_key)
+
+        expect(mapping).to_not eq(mapping2)
+      end
+    end
+
+    context 'when a cache_key is given' do
+      it 'builds a new mapping and re-uses it on the second time' do
+        mapping = described_class.retrieve_mapping(cache_key)
+
+        expect(mapping[:base]).to eq(described_class::BASE_MAPPING)
+        expect(mapping[:replacement].class).to eq(String)
+
+        mapping2 = described_class.retrieve_mapping(cache_key)
+
+        expect(mapping).to eq(mapping2)
+      end
+    end
+  end
+
+  describe '.build_mapped_digit_snippet' do
+    let(:mapping) do
+      {
+        base:        '0123456789',
+        replacement: '5678901234'
+      }
+    end
+
+    before do
+      allow(described_class)
+        .to receive(:retrieve_mapping)
+        .with(cache_key)
+        .and_return(mapping)
+    end
+
+    let(:build_mapped_digit_snippet_call) do
+      described_class.build_mapped_digit_snippet(column_name, options)
+    end
+
+    let(:length) { nil }
+
+    it 'builds the barcode with individually mapped digits' do
+      expect(build_mapped_digit_snippet_call)
+        .to eq(
+          <<-SQL
+          SELECT
+            *
+          FROM (
+            SELECT
+              ROW_NUMBER() over () AS pos,
+              digit::INT
+            FROM (
+              SELECT
+                REGEXP_SPLIT_TO_TABLE(
+                  SUBSTRING(ean::TEXT, 1, 2) ||  TRANSLATE( SUBSTRING(ean::TEXT, 3, LENGTH(ean::TEXT) - 1), '0123456789', '5678901234' ),
+                  ''
+                ) AS digit
+            ) AS sub
+          ) AS sub
+          WHERE pos < LENGTH(ean::TEXT)
+          SQL
+        )
+    end
+  end
+
+  describe '.build_digit_mapping' do
+    let(:mapping) do
+      {
+        base:        '0123456789',
+        replacement: '5678901234'
+      }
+    end
+
+    before do
+      allow(described_class)
+        .to receive(:retrieve_mapping)
+        .with(cache_key)
+        .and_return(mapping)
+    end
+
+    let(:build_digit_mapping_call) do
+      described_class.build_digit_mapping(column_name, options)
+    end
+
+    context 'when no start or length is defined' do
+      let(:start)  { nil }
+      let(:length) { nil }
+
+      it 'builds only the translate part' do
+        expect(build_digit_mapping_call)
+          .to eq(
+            [
+              " TRANSLATE( SUBSTRING(ean::TEXT, 1, LENGTH(ean::TEXT) - 1), '0123456789', '5678901234' )",
+            ]
+          )
+      end
+    end
+
+    context 'when start is defined' do
+      let(:length) { nil }
+
+      it 'builds the start substring and translate part' do
+        expect(build_digit_mapping_call)
+          .to eq(
+            [
+              "SUBSTRING(ean::TEXT, 1, 2)",
+              " TRANSLATE( SUBSTRING(ean::TEXT, 3, LENGTH(ean::TEXT) - 1), '0123456789', '5678901234' )"
+            ]
+          )
+      end
+    end
+
+    context 'when length is defined' do
+      let(:start)  { nil }
+
+      it 'translate and end substring part' do
+        expect(build_digit_mapping_call)
+          .to eq(
+            [
+              " TRANSLATE( SUBSTRING(ean::TEXT, 1, 7), '0123456789', '5678901234' )",
+              'SUBSTRING(ean::TEXT, 1 + 7, LENGTH(ean::TEXT) - 1 - 1)'
+            ]
+          )
+      end
+    end
+
+    context 'when start and length are defined' do
+      it 'builds start, translate, and end parts' do
+        expect(build_digit_mapping_call)
+          .to eq(
+            [
+              'SUBSTRING(ean::TEXT, 1, 2)',
+              " TRANSLATE( SUBSTRING(ean::TEXT, 3, 7), '0123456789', '5678901234' )",
+              'SUBSTRING(ean::TEXT, 3 + 7, LENGTH(ean::TEXT) - 1 - 3)'
+            ]
+          )
+      end
+    end
+  end
+
+  describe '.build_substring_snippet' do
+    let(:build_substring_snippet_call) do
+      described_class.build_substring_snippet(column_name, start, length)
+    end
+
+    it 'builds a SUBTRING snippet' do
+      expect(build_substring_snippet_call)
+        .to eq('SUBSTRING(ean::TEXT, 3, 7)')
+    end
+  end
+end


### PR DESCRIPTION
This adds a method to anonymize ean code while still keeping a valid check digit.
This can be used to ensure that any ean codes in a database would not be directly usable from a dump.