### PR TITLE
Support Active Record 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: ruby
 rvm:
-  - 2.1.0
-  - 2.4.1
-  - 2.5.0
-  - 2.6.0
+  - 2.5.7
+  - 2.6.3
+  - 2.7.0
 before_install: gem install bundler -v '1.17.3'
 script:
   - bundle exec rspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,53 +1,56 @@
 PATH
   remote: .
   specs:
-    tidus (1.1.0)
+    tidus (1.2.0)
       activerecord (>= 3.2)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (4.2.11)
-      activesupport (= 4.2.11)
-      builder (~> 3.1)
-    activerecord (4.2.11)
-      activemodel (= 4.2.11)
-      activesupport (= 4.2.11)
-      arel (~> 6.0)
-    activesupport (4.2.11)
-      i18n (~> 0.7)
+    activemodel (6.0.2.1)
+      activesupport (= 6.0.2.1)
+    activerecord (6.0.2.1)
+      activemodel (= 6.0.2.1)
+      activesupport (= 6.0.2.1)
+    activesupport (6.0.2.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
       minitest (~> 5.1)
-      thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
-    arel (6.0.4)
-    builder (3.2.3)
-    concurrent-ruby (1.1.3)
-    diff-lcs (1.2.5)
-    i18n (0.9.5)
+      zeitwerk (~> 2.2)
+    concurrent-ruby (1.1.6)
+    diff-lcs (1.3)
+    i18n (1.8.2)
       concurrent-ruby (~> 1.0)
-    minitest (5.11.3)
-    rake (10.0.4)
-    rspec (2.14.1)
-      rspec-core (~> 2.14.0)
-      rspec-expectations (~> 2.14.0)
-      rspec-mocks (~> 2.14.0)
-    rspec-core (2.14.8)
-    rspec-expectations (2.14.5)
-      diff-lcs (>= 1.1.3, < 2.0)
-    rspec-mocks (2.14.6)
-    sqlite3 (1.3.10)
+    minitest (5.14.0)
+    rake (13.0.1)
+    rspec (3.9.0)
+      rspec-core (~> 3.9.0)
+      rspec-expectations (~> 3.9.0)
+      rspec-mocks (~> 3.9.0)
+    rspec-core (3.9.1)
+      rspec-support (~> 3.9.1)
+    rspec-expectations (3.9.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.9.0)
+    rspec-mocks (3.9.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.9.0)
+    rspec-support (3.9.2)
+    sqlite3 (1.4.2)
     thread_safe (0.3.6)
-    tzinfo (1.2.5)
+    tzinfo (1.2.6)
       thread_safe (~> 0.1)
+    zeitwerk (2.2.2)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  rake (~> 10.0.4)
-  rspec (~> 2.14.1)
-  sqlite3 (~> 1.3.10)
+  rake (~> 13.0)
+  rspec (~> 3.9)
+  sqlite3 (~> 1.4)
   tidus!
 
 BUNDLED WITH
-   1.17.2
+   1.17.3

--- a/lib/tasks/views.rake
+++ b/lib/tasks/views.rake
@@ -1,9 +1,16 @@
+skip_tables = [
+  'schema_migrations',
+  'ar_internal_metadata',
+]
+
 namespace :db do
   desc "Clears all the views which are currently existing"
   task :clear_views do
     Rails.application.eager_load! if defined?(Rails)
+
     ActiveRecord::Base.descendants.each do |c|
-      next if c.table_name == "schema_migrations"
+      next if skip_tables.include?(c.table_name)
+
       puts "Clearing view '#{c.view_name}' for table '#{c.table_name}'"
 
       c.clear_view
@@ -13,8 +20,9 @@ namespace :db do
   desc "Generates all the views for the models"
   task :generate_views do
     Rails.application.eager_load! if defined?(Rails)
+
     ActiveRecord::Base.descendants.each do |c|
-      next if c.table_name == "schema_migrations" || c.skip_anonymization?
+      next if skip_tables.include?(c.table_name) || c.skip_anonymization?
 
       if ActiveRecord::Base.connection.table_exists? c.table_name
         puts "Generating view '#{c.view_name}' for table '#{c.table_name}'"

--- a/lib/tidus.rb
+++ b/lib/tidus.rb
@@ -9,5 +9,5 @@ require "tidus/anonymization"
 require "tidus/strategies/base_selector"
 Dir["#{File.dirname(__FILE__)}/tidus/strategies/**/*.rb"].each { |f| require f }
 
-load "active_record/railties/databases.rake"
+load "active_record/railties/databases.rake" if defined?(Rails)
 load "tasks/views.rake"

--- a/lib/tidus/version.rb
+++ b/lib/tidus/version.rb
@@ -1,3 +1,3 @@
 module Tidus
-  VERSION = "1.1.0"
+  VERSION = "1.2.0"
 end

--- a/spec/lib/tasks/views_rake_spec.rb
+++ b/spec/lib/tasks/views_rake_spec.rb
@@ -16,14 +16,25 @@ describe "database view clearing rake task" do
 
     it "executes the rake task" do
       schema_migrations = Object.new
-      schema_migrations.should_receive(:table_name).and_return("schema_migrations")
+      expect(schema_migrations).to receive(:table_name).and_return("schema_migrations")
+
+      ar_internal_metadata = Object.new
+      expect(ar_internal_metadata).to receive(:table_name).and_return("ar_internal_metadata")
 
       another_table = Object.new
-      another_table.should_receive(:table_name).exactly(2).times.and_return("another_table")
-      another_table.should_receive(:view_name).and_return("another_table_anonymized")
-      another_table.should_receive(:clear_view)
+      expect(another_table)
+        .to receive(:table_name)
+        .exactly(2).times
+        .and_return("another_table")
+      expect(another_table)
+        .to receive(:view_name)
+        .and_return("another_table_anonymized")
+      expect(another_table)
+        .to receive(:clear_view)
 
-      ActiveRecord::Base.should_receive(:descendants).and_return([schema_migrations, another_table])
+      expect(ActiveRecord::Base)
+        .to receive(:descendants)
+        .and_return([schema_migrations, ar_internal_metadata, another_table])
       @rake[@rake_task_name].invoke
     end
   end
@@ -36,30 +47,49 @@ describe "database view clearing rake task" do
 
     it "executes the rake task" do
       schema_migrations = Object.new
-      schema_migrations.should_receive(:table_name).and_return("schema_migrations")
+      expect(schema_migrations).to receive(:table_name).and_return("schema_migrations")
+
+      ar_internal_metadata = Object.new
+      expect(ar_internal_metadata).to receive(:table_name).and_return("ar_internal_metadata")
 
       nonexistent = Object.new
-      nonexistent.should_receive(:table_name).exactly(2).times.and_return("nonexistent")
-      nonexistent.should_receive(:skip_anonymization?)
+      expect(nonexistent).to receive(:table_name).exactly(2).times.and_return("nonexistent")
+      expect(nonexistent).to receive(:skip_anonymization?)
 
       skip_anonymization = Object.new
       skip_anonymization.should_receive(:table_name).and_return("skip")
       skip_anonymization.should_receive(:skip_anonymization?).and_return(true)
 
       another_table = Object.new
-      another_table.should_receive(:table_name).exactly(3).times.and_return("another_table")
-      another_table.should_receive(:view_name).and_return("another_table_anonymized")
-      another_table.should_receive(:create_view)
-      another_table.should_receive(:skip_anonymization?)
+      expect(another_table).to receive(:table_name).exactly(3).times.and_return("another_table")
+      expect(another_table).to receive(:view_name).and_return("another_table_anonymized")
+      expect(another_table).to receive(:create_view)
+      expect(another_table).to receive(:skip_anonymization?)
 
-      ActiveRecord::Base.should_receive(:descendants)
-                        .and_return([schema_migrations, another_table,
-                                     nonexistent, skip_anonymization])
+      expect(ActiveRecord::Base)
+        .to receive(:descendants)
+        .and_return(
+          [
+            schema_migrations,
+            ar_internal_metadata,
+            another_table,
+            nonexistent,
+            skip_anonymization,
+          ],
+        )
       connection = Object.new
-      ActiveRecord::Base.should_receive(:connection).exactly(2).times
-                        .and_return(connection)
-      connection.should_receive(:table_exists?).with("nonexistent").and_return(false)
-      connection.should_receive(:table_exists?).with("another_table").and_return(true)
+      expect(ActiveRecord::Base)
+        .to receive(:connection)
+        .exactly(2).times
+        .and_return(connection)
+      expect(connection)
+        .to receive(:table_exists?)
+        .with("nonexistent")
+        .and_return(false)
+      expect(connection)
+        .to receive(:table_exists?)
+        .with("another_table")
+        .and_return(true)
       @rake[@rake_task_name].invoke
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,9 @@
 # encoding: utf-8
 
+require "rake"
+
+load "active_record/railties/databases.rake"
+
 Dir[File.dirname(__FILE__) + '/../lib/*.rb'].each  { |file| require file }
 Dir["./spec/support/*.rb"].each { |f| require f }
 require 'active_record'
@@ -9,7 +13,6 @@ RSpec.configure do |config|
   # The following 3 lines make this possible:
   config.filter_run :focus => true
   config.run_all_when_everything_filtered = true
-  config.treat_symbols_as_metadata_keys_with_true_values = true
 
   config.mock_with :rspec do |c|
     c.syntax = [:should, :expect]

--- a/tidus.gemspec
+++ b/tidus.gemspec
@@ -19,9 +19,9 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "rake",                        "~> 10.0.4"
-  spec.add_development_dependency "rspec",                       "~> 2.14.1"
-  spec.add_development_dependency "sqlite3",                     "~> 1.3.10"
+  spec.add_development_dependency "rake",    "~> 13.0"
+  spec.add_development_dependency "rspec",   "~> 3.9"
+  spec.add_development_dependency "sqlite3", "~> 1.4"
 
   spec.add_dependency "activerecord", ">= 3.2"
 end


### PR DESCRIPTION
With newer active record version `ar_internal_metadata` was introduced as a table.
Tidus should also ignore this column